### PR TITLE
Add link to go-distribution port

### DIFF
--- a/README.md
+++ b/README.md
@@ -826,6 +826,10 @@ I imagine, in order of nice-to-haveness:
  * Java
  * Ruby
 
+ List of known ports
+ -------------------
+ 1. [go-distribution](https://github.com/bradfordboyle/go-distribution)
+
 
 Authors
 =======


### PR DESCRIPTION
The Go port was barely started and then abandoned. Prerequisite would be writing/finishing the Go port.

 - [ ] First write/finish the Go Port
 - [ ] Then create its own repo
 - [ ] Then link to it