### PR TITLE
Add Existing Values

### DIFF
--- a/distribution.py
+++ b/distribution.py
@@ -253,7 +253,10 @@ class InputReader(object):
 			for line in sys.stdin:
 				m = vk.match(line)
 				try:
-					self.tokenDict[m.group(2)] = int(m.group(1))
+					if m.group(2) in self.tokenDict:
+						self.tokenDict[m.group(2)] += int(m.group(1))
+					else:
+						self.tokenDict[m.group(2)] = int(m.group(1))
 					s.totalValues += int(m.group(1))
 					s.totalObjects += 1
 				except:
@@ -262,7 +265,10 @@ class InputReader(object):
 			for line in sys.stdin:
 				m = kv.match(line)
 				try:
-					self.tokenDict[m.group(1)] = int(m.group(2))
+					if m.group(1) in self.tokenDict:
+						self.tokenDict[m.group(1)] += int(m.group(2))
+					else:
+						self.tokenDict[m.group(1)] = int(m.group(2))
 					s.totalValues += int(m.group(2))
 					s.totalObjects += 1
 				except:


### PR DESCRIPTION
The documentation says this is supported, and I know I used this feature, but I must have never pushed it into the repo. Adding it now.

If you do kv or vk graphing, and you get duplicate keys, sum the values instead of replacing them.